### PR TITLE
make cpuconstaints easy set in one place and add preemptible instances

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/utils/env"
+	"strconv"
+	"strings"
 )
 
 func init() {
@@ -49,6 +51,14 @@ type Options struct {
 	UseLocalPriceList       bool
 }
 
+func generateDefaultFlexCpuConstrainList() string {
+	var values []string
+	for i := 1; i <= 256; i++ {
+		values = append(values, strconv.Itoa(i))
+	}
+	return strings.Join(values, ",")
+}
+
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "[REQUIRED] The kubernetes cluster name for resource discovery.")
 	fs.StringVar(&o.ClusterEndpoint, "cluster-endpoint", env.WithDefaultString("CLUSTER_ENDPOINT", ""), "The external kubernetes cluster endpoint for new nodes to connect with. If not specified, will discover the cluster endpoint using DescribeCluster API.")
@@ -57,7 +67,11 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.BootStrapToken, "cluster-bootstrap-token", env.WithDefaultString("CLUSTER_BOOTSTRAP_TOKEN", ""), "Cluster bootstrap token for nodes to use for TLS connections with the API server, use bootstrap token generate kube config")
 	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent", utils.WithDefaultFloat64("VM_MEMORY_OVERHEAD_PERCENT", 0.0), "The VM memory overhead as a percent that will be subtracted from the total memory for all instance types.")
 	fs.StringVar(&o.FlexCpuMemRatios, "flex-cpu-mem-ratios", env.WithDefaultString("FLEX_CPU_MEM_RATIOS", "4"), "the ratios of vcpu and mem, eg FLEX_CPU_MEM_RATIOS=2,4, if create flex instance with 2 cores(1 ocpu), mem should be 4Gi or 8Gi")
-	fs.StringVar(&o.FlexCpuConstrainList, "flex-cpu-constrain-list", env.WithDefaultString("FLEX_CPU_CONSTRAIN_LIST", "1,2,4,8,16,32,48,64,96,128"), "to constrain the ocpu cores of flex instance, instance create in this cpu size list, ocpu is twice of vcpu")
+
+	// just need to set cpu constraints in nodepool yaml
+	defaultFlexCpuConstrainList := env.WithDefaultString("FLEX_CPU_CONSTRAIN_LIST", generateDefaultFlexCpuConstrainList())
+	fs.StringVar(&o.FlexCpuConstrainList, "flex-cpu-constrain-list", defaultFlexCpuConstrainList, "to constrain the ocpu cores of flex instance, instance create in this cpu size list, ocpu is twice of vcpu")
+
 	fs.StringVar(&o.CompartmentId, "compartment-id", env.WithDefaultString("COMPARTMENT_ID", ""), "[REQUIRED] The compartment id to create and list instances")
 	fs.StringVar(&o.TagNamespace, "tag-namespace", env.WithDefaultString("TAG_NAMESPACE", "oke-karpenter-ns"), "[REQUIRED] The tag namespace used to create and list instances")
 	fs.StringVar(&o.OciAuthMethods, "oci-auth-methods", env.WithDefaultString("OCI_AUTH_METHODS", "OKE"), "[REQUIRED] the auth method to access oracle cloud resource, support OKE,API_KEY,SESSION,INSTANCE_PRINCIPAL")

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -106,7 +106,12 @@ func (p *Provider) Create(ctx context.Context, nodeClass *v1alpha1.OciNodeClass,
 		return nil, err
 	}
 	metadata["user_data"] = userdata
-
+	// Determine capacity type based on node requirements
+	capacityType := corev1.CapacityTypeOnDemand
+	nodeReqs := scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...)
+	if nodeReqs.Get(corev1.CapacityTypeLabelKey).Has("preemptible") {
+		capacityType = "preemptible"
+	}
 	req := core.LaunchInstanceRequest{LaunchInstanceDetails: core.LaunchInstanceDetails{
 		// todo subnet id balance
 		CreateVnicDetails:       &core.CreateVnicDetails{SubnetId: subnets[0].Id, NsgIds: sgsIds},
@@ -123,6 +128,14 @@ func (p *Provider) Create(ctx context.Context, nodeClass *v1alpha1.OciNodeClass,
 		Metadata:           metadata,
 		InstanceOptions:    &core.InstanceOptions{AreLegacyImdsEndpointsDisabled: common.Bool(true)},
 	}}
+	// Set preemptible flag if needed
+	if capacityType == "preemptible" {
+		req.LaunchInstanceDetails.PreemptibleInstanceConfig = &core.PreemptibleInstanceConfigDetails{
+			PreemptionAction: core.TerminatePreemptionAction{
+				PreserveBootVolume: common.Bool(false),
+			},
+		}
+	}
 
 	// for flexible instance, specify the ocpu and memory
 	if instanceType.Requirements.Get(v1alpha1.LabelIsFlexible).Has("true") {
@@ -194,6 +207,7 @@ func pickBestInstanceType(nodeClaim *corev1.NodeClaim, instanceTypes corecloudpr
 	if len(instanceTypes) == 0 {
 		return nil, ""
 	}
+
 	sortedInstanceType := instanceTypes.OrderByPrice(scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...))
 	instanceType := sortedInstanceType[0]
 	// Zone - ideally random/spread from requested zones that support given Priority

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -77,9 +77,26 @@ func (p *Provider) CreateOfferings(shape *internalmodel.WrapShape, zones sets.Se
 	if p.priceSyncer != nil {
 		priceCatalog = &p.priceSyncer.PriceCatalog
 	}
+	basePrice := float64(pricing.Calculate(shape, priceCatalog))
 
 	// only on-demand support
 	for zone := range zones {
+		// Add preemptible offering with lower price (higher priority)
+		isPreemptibleUnavailable := p.unavailableOfferings.IsUnavailable(*shape.Shape.Shape, zone, v1.CapacityTypeSpot)
+		if !isPreemptibleUnavailable {
+			// Lower price means higher priority when sorting by price
+			preemptiblePrice := basePrice * 0.5
+
+			offerings = append(offerings, cloudprovider.Offering{
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, v1.CapacityTypeSpot),
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, zone),
+				),
+				Price:     preemptiblePrice,
+				Available: true,
+			})
+		}
+
 		// exclude any offerings that have recently seen an insufficient capacity error
 		isUnavailable := p.unavailableOfferings.IsUnavailable(*shape.Shape.Shape, zone, v1.CapacityTypeOnDemand) // todo support pricing calculate
 
@@ -93,6 +110,13 @@ func (p *Provider) CreateOfferings(shape *internalmodel.WrapShape, zones sets.Se
 			Available: !isUnavailable,
 		})
 		// metric
+		// add preemptible metrics
+		instanceTypeOfferingAvailable.With(prometheus.Labels{
+			instanceTypeLabel: *shape.Shape.Shape,
+			capacityTypeLabel: v1.CapacityTypeSpot,
+			zoneLabel:         zone,
+		}).Set(float64(lo.Ternary(!isPreemptibleUnavailable, 1, 0)))
+		// add ondemand instances metrics
 		instanceTypeOfferingAvailable.With(prometheus.Labels{
 			instanceTypeLabel: *shape.Shape.Shape,
 			capacityTypeLabel: v1.CapacityTypeOnDemand,
@@ -102,6 +126,11 @@ func (p *Provider) CreateOfferings(shape *internalmodel.WrapShape, zones sets.Se
 		instanceTypeOfferingPriceEstimate.With(prometheus.Labels{
 			instanceTypeLabel: fmt.Sprintf("%s_%d_%d", *shape.Shape.Shape, shape.CalcCpu/2, shape.CalMemInGBs),
 			capacityTypeLabel: v1.CapacityTypeOnDemand,
+			zoneLabel:         zone,
+		}).Set(price)
+		instanceTypeOfferingPriceEstimate.With(prometheus.Labels{
+			instanceTypeLabel: fmt.Sprintf("%s_%d_%d", *shape.Shape.Shape, shape.CalcCpu/2, shape.CalMemInGBs),
+			capacityTypeLabel: v1.CapacityTypeSpot,
 			zoneLabel:         zone,
 		}).Set(price)
 	}


### PR DESCRIPTION
make cpuconstaints easy to be set in one place and add preemptible instances.

to enable preemptible provision, just add - preemptible  to  in nodepool 

e.g.  in nodepool.yaml
```
  requirements:
        - key: karpenter.sh/capacity-type
          operator: In
          values:
            - on-demand
            - preemptible
```
if we dont want to use preemptible, just dont add preemptible in above yaml, leave on-demand only 