### PR TITLE
streamline cpu constraints settings in one place and add preemptible support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ spec:
           operator: In
           values:
             - on-demand
+            ### if you wanna enable preemptible instances creation for lower cost, add below line.
+            - preemptible
         - key: karpenter.k8s.oracle/instance-shape-name
           operator: In
           values:

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -311,6 +311,9 @@ func (c *CloudProvider) instanceToNodeClaim(ctx context.Context, i *core.Instanc
 	// labels[v1.LabelFailureDomainBetaZone] = *i.FaultDomain
 
 	labels[corev1.CapacityTypeLabelKey] = corev1.CapacityTypeOnDemand
+	if i.PreemptibleInstanceConfig != nil {
+		labels[corev1.CapacityTypeLabelKey] = utils.CapacityTypePreemptible
+	}
 	if v, ok := i.DefinedTags[options.FromContext(ctx).TagNamespace][utils.SafeTagKey(corev1.NodePoolLabelKey)]; ok {
 		labels[corev1.NodePoolLabelKey] = v.(string)
 	}

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -23,6 +23,8 @@ import (
 	"os"
 	coreoptions "sigs.k8s.io/karpenter/pkg/operator/options"
 	"sigs.k8s.io/karpenter/pkg/utils/env"
+	"strconv"
+	"strings"
 )
 
 func init() {
@@ -49,6 +51,14 @@ type Options struct {
 	UseLocalPriceList       bool
 }
 
+func generateDefaultFlexCpuConstrainList() string {
+	var values []string
+	for i := 1; i <= 256; i++ {
+		values = append(values, strconv.Itoa(i))
+	}
+	return strings.Join(values, ",")
+}
+
 func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.ClusterName, "cluster-name", env.WithDefaultString("CLUSTER_NAME", ""), "[REQUIRED] The kubernetes cluster name for resource discovery.")
 	fs.StringVar(&o.ClusterEndpoint, "cluster-endpoint", env.WithDefaultString("CLUSTER_ENDPOINT", ""), "The external kubernetes cluster endpoint for new nodes to connect with. If not specified, will discover the cluster endpoint using DescribeCluster API.")
@@ -57,7 +67,11 @@ func (o *Options) AddFlags(fs *coreoptions.FlagSet) {
 	fs.StringVar(&o.BootStrapToken, "cluster-bootstrap-token", env.WithDefaultString("CLUSTER_BOOTSTRAP_TOKEN", ""), "Cluster bootstrap token for nodes to use for TLS connections with the API server, use bootstrap token generate kube config")
 	fs.Float64Var(&o.VMMemoryOverheadPercent, "vm-memory-overhead-percent", utils.WithDefaultFloat64("VM_MEMORY_OVERHEAD_PERCENT", 0.0), "The VM memory overhead as a percent that will be subtracted from the total memory for all instance types.")
 	fs.StringVar(&o.FlexCpuMemRatios, "flex-cpu-mem-ratios", env.WithDefaultString("FLEX_CPU_MEM_RATIOS", "4"), "the ratios of vcpu and mem, eg FLEX_CPU_MEM_RATIOS=2,4, if create flex instance with 2 cores(1 ocpu), mem should be 4Gi or 8Gi")
-	fs.StringVar(&o.FlexCpuConstrainList, "flex-cpu-constrain-list", env.WithDefaultString("FLEX_CPU_CONSTRAIN_LIST", "1,2,4,8,16,32,48,64,96,128"), "to constrain the ocpu cores of flex instance, instance create in this cpu size list, ocpu is twice of vcpu")
+
+	// just need to set cpu constraints in nodepool yaml
+	defaultFlexCpuConstrainList := env.WithDefaultString("FLEX_CPU_CONSTRAIN_LIST", generateDefaultFlexCpuConstrainList())
+	fs.StringVar(&o.FlexCpuConstrainList, "flex-cpu-constrain-list", defaultFlexCpuConstrainList, "to constrain the ocpu cores of flex instance, instance create in this cpu size list, ocpu is twice of vcpu")
+
 	fs.StringVar(&o.CompartmentId, "compartment-id", env.WithDefaultString("COMPARTMENT_ID", ""), "[REQUIRED] The compartment id to create and list instances")
 	fs.StringVar(&o.TagNamespace, "tag-namespace", env.WithDefaultString("TAG_NAMESPACE", "oke-karpenter-ns"), "[REQUIRED] The tag namespace used to create and list instances")
 	fs.StringVar(&o.OciAuthMethods, "oci-auth-methods", env.WithDefaultString("OCI_AUTH_METHODS", "OKE"), "[REQUIRED] the auth method to access oracle cloud resource, support OKE,API_KEY,SESSION,INSTANCE_PRINCIPAL")

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -16,6 +16,7 @@ package instance_test
 
 import (
 	"context"
+	"fmt"
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/samber/lo"
@@ -26,6 +27,7 @@ import (
 	"github.com/zoom/karpenter-oci/pkg/operator/options"
 	"github.com/zoom/karpenter-oci/pkg/test"
 	"github.com/zoom/karpenter-oci/pkg/utils"
+	v1core "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -160,5 +162,40 @@ var _ = Describe("InstanceProvider", func() {
 
 		retrievedIDs := sets.New[string](lo.Map(instances, func(i core.Instance, _ int) string { return *i.Id })...)
 		Expect(ids.Equal(retrievedIDs)).To(BeTrue())
+	})
+	It("should create preemptible instance when requested", func() {
+		ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+		ociEnv.CmpCli.InsufficientCapacityPools.Set([]fake.CapacityPool{
+			{CapacityType: v1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "US-ASHBURN-AD-1"},
+			{CapacityType: v1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "US-ASHBURN-AD-2"},
+			{CapacityType: v1.CapacityTypeOnDemand, InstanceType: "m5.xlarge", Zone: "US-ASHBURN-AD-3"},
+		})
+		nodeClaim.Spec.Requirements = append(nodeClaim.Spec.Requirements, v1.NodeSelectorRequirementWithMinValues{
+			NodeSelectorRequirement: v1core.NodeSelectorRequirement{
+				Key:      v1.CapacityTypeLabelKey,
+				Operator: v1core.NodeSelectorOpIn,
+				Values:   []string{"preemptible"},
+			},
+		})
+
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		fmt.Printf("Total instance types: %d\n", len(instanceTypes))
+		for i, it := range instanceTypes {
+			fmt.Printf("\nInstance Type #%d:\n", i+1)
+			fmt.Printf("  Name: %s\n", it.Name)
+		}
+		Expect(err).ToNot(HaveOccurred())
+
+		// Filter down to a single instance type for testing
+		instanceTypes = lo.Filter(instanceTypes, func(i *corecloudprovider.InstanceType, _ int) bool {
+			return i.Name == "shape-1"
+		})
+
+		instance, err := ociEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, instanceTypes)
+
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instance).ToNot(BeNil())
+
 	})
 })

--- a/pkg/providers/instancetype/instancetype.go
+++ b/pkg/providers/instancetype/instancetype.go
@@ -17,6 +17,10 @@ package instancetype
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+
 	"github.com/oracle/oci-go-sdk/v65/common"
 	"github.com/oracle/oci-go-sdk/v65/core"
 	"github.com/patrickmn/go-cache"
@@ -28,14 +32,12 @@ import (
 	"github.com/zoom/karpenter-oci/pkg/operator/options"
 	"github.com/zoom/karpenter-oci/pkg/providers/internalmodel"
 	"github.com/zoom/karpenter-oci/pkg/providers/pricing"
+	"github.com/zoom/karpenter-oci/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	v1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	"sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
-	"strconv"
-	"strings"
-	"sync"
 )
 
 const (
@@ -77,9 +79,26 @@ func (p *Provider) CreateOfferings(shape *internalmodel.WrapShape, zones sets.Se
 	if p.priceSyncer != nil {
 		priceCatalog = &p.priceSyncer.PriceCatalog
 	}
+	basePrice := float64(pricing.Calculate(shape, priceCatalog))
 
 	// only on-demand support
 	for zone := range zones {
+		// Add preemptible offering with lower price (higher priority)
+		isPreemptibleUnavailable := p.unavailableOfferings.IsUnavailable(*shape.Shape.Shape, zone, utils.CapacityTypePreemptible)
+		if !isPreemptibleUnavailable {
+			// Lower price means higher priority when sorting by price
+			preemptiblePrice := basePrice * 0.5
+
+			offerings = append(offerings, cloudprovider.Offering{
+				Requirements: scheduling.NewRequirements(
+					scheduling.NewRequirement(v1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, utils.CapacityTypePreemptible),
+					scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, zone),
+				),
+				Price:     preemptiblePrice,
+				Available: true,
+			})
+		}
+
 		// exclude any offerings that have recently seen an insufficient capacity error
 		isUnavailable := p.unavailableOfferings.IsUnavailable(*shape.Shape.Shape, zone, v1.CapacityTypeOnDemand) // todo support pricing calculate
 
@@ -93,6 +112,13 @@ func (p *Provider) CreateOfferings(shape *internalmodel.WrapShape, zones sets.Se
 			Available: !isUnavailable,
 		})
 		// metric
+		// add preemptible metrics
+		instanceTypeOfferingAvailable.With(prometheus.Labels{
+			instanceTypeLabel: *shape.Shape.Shape,
+			capacityTypeLabel: utils.CapacityTypePreemptible,
+			zoneLabel:         zone,
+		}).Set(float64(lo.Ternary(!isPreemptibleUnavailable, 1, 0)))
+		// add ondemand instances metrics
 		instanceTypeOfferingAvailable.With(prometheus.Labels{
 			instanceTypeLabel: *shape.Shape.Shape,
 			capacityTypeLabel: v1.CapacityTypeOnDemand,
@@ -102,6 +128,11 @@ func (p *Provider) CreateOfferings(shape *internalmodel.WrapShape, zones sets.Se
 		instanceTypeOfferingPriceEstimate.With(prometheus.Labels{
 			instanceTypeLabel: fmt.Sprintf("%s_%d_%d", *shape.Shape.Shape, shape.CalcCpu/2, shape.CalMemInGBs),
 			capacityTypeLabel: v1.CapacityTypeOnDemand,
+			zoneLabel:         zone,
+		}).Set(price)
+		instanceTypeOfferingPriceEstimate.With(prometheus.Labels{
+			instanceTypeLabel: fmt.Sprintf("%s_%d_%d", *shape.Shape.Shape, shape.CalcCpu/2, shape.CalMemInGBs),
+			capacityTypeLabel: utils.CapacityTypePreemptible,
 			zoneLabel:         zone,
 		}).Set(price)
 	}

--- a/pkg/providers/instancetype/suite_test.go
+++ b/pkg/providers/instancetype/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/zoom/karpenter-oci/pkg/utils"
 	"github.com/awslabs/operatorpkg/status"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -666,6 +667,10 @@ var _ = Describe("InstanceTypeProvider", func() {
 				{CapacityType: karpv1.CapacityTypeOnDemand, InstanceType: "shape-3", Zone: "US-ASHBURN-AD-2"},
 				{CapacityType: karpv1.CapacityTypeOnDemand, InstanceType: "shape-3", Zone: "US-ASHBURN-AD-3"},
 			})
+        	ociEnv.UnavailableOfferingsCache.MarkUnavailable(ctx, "test", "shape-3", "US-ASHBURN-AD-1", utils.CapacityTypePreemptible)
+			ociEnv.UnavailableOfferingsCache.MarkUnavailable(ctx, "test", "shape-3", "US-ASHBURN-AD-2", utils.CapacityTypePreemptible)
+			ociEnv.UnavailableOfferingsCache.MarkUnavailable(ctx, "test", "shape-3", "US-ASHBURN-AD-3", utils.CapacityTypePreemptible)
+
 			nodePool.Spec.Template.Spec.Requirements = nil
 			nodePool.Spec.Template.Spec.Requirements = append(nodePool.Spec.Template.Spec.Requirements, karpv1.NodeSelectorRequirementWithMinValues{
 				NodeSelectorRequirement: v1.NodeSelectorRequirement{

--- a/pkg/utils/oci.go
+++ b/pkg/utils/oci.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 )
 
+// define a constant for preemptible instance
+const CapacityTypePreemptible = "preemptible"
+
 func ConvertLaunchOptions(m *v1alpha1.LaunchOptions) (*core.LaunchOptions, error) {
 	errMessage := []string{}
 	ociLaunchOptions := &core.LaunchOptions{}


### PR DESCRIPTION
 ppl just need to set available cpu in nodepool, all the possible cpu in shapes are auto populated.
make nodeclaim capacity type as preemptible, and modified one unit test