### PR TITLE
fix: preemptible to on-demand fallback on ICE errors

### DIFF
--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -71,7 +72,7 @@ func (p *Provider) Create(ctx context.Context, nodeClass *v1alpha1.OciNodeClass,
 	sgsIds := lo.Map[*v1alpha1.SecurityGroup, string](nodeClass.Status.SecurityGroups, func(item *v1alpha1.SecurityGroup, index int) string {
 		return item.Id
 	})
-	instanceType, zone := pickBestInstanceType(nodeClaim, instanceTypes)
+	instanceType, zone, capacityType := pickBestInstanceType(nodeClaim, instanceTypes)
 	ad, ok := lo.Find(options.FromContext(ctx).AvailableDomains, func(item string) bool {
 		return strings.Contains(item, zone)
 	})
@@ -83,6 +84,7 @@ func (p *Provider) Create(ctx context.Context, nodeClass *v1alpha1.OciNodeClass,
 		log.FromContext(ctx).V(1).Error(corecloudprovider.NewInsufficientCapacityError(fmt.Errorf("no instance types available")), "")
 		return nil, corecloudprovider.NewInsufficientCapacityError(fmt.Errorf("no instance types available"))
 	}
+	log.FromContext(ctx).V(1).Info("selected instance type", "instanceType", instanceType.Name, "zone", zone, "capacityType", capacityType)
 	blockDevices := lo.Map[*v1alpha1.VolumeAttributes, core.LaunchAttachVolumeDetails](nodeClass.Spec.BlockDevices,
 		func(item *v1alpha1.VolumeAttributes, index int) core.LaunchAttachVolumeDetails {
 			return core.LaunchAttachIScsiVolumeDetails{
@@ -110,12 +112,7 @@ func (p *Provider) Create(ctx context.Context, nodeClass *v1alpha1.OciNodeClass,
 		return nil, err
 	}
 	metadata["user_data"] = userdata
-	// Determine capacity type based on node requirements
-	capacityType := corev1.CapacityTypeOnDemand
-	nodeReqs := scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...)
-	if nodeReqs.Get(corev1.CapacityTypeLabelKey).Has(v1alpha1.CapacityTypePreemptible) {
-		capacityType = v1alpha1.CapacityTypePreemptible
-	}
+
 	req := core.LaunchInstanceRequest{LaunchInstanceDetails: core.LaunchInstanceDetails{
 		CreateVnicDetails:       &core.CreateVnicDetails{SubnetId: subnet.Id, NsgIds: sgsIds},
 		LaunchVolumeAttachments: blockDevices,
@@ -245,9 +242,9 @@ func removeExcludingChars(sizeLimit int, tags ...map[string]string) map[string]i
 	return res
 }
 
-func pickBestInstanceType(nodeClaim *corev1.NodeClaim, instanceTypes corecloudprovider.InstanceTypes) (*corecloudprovider.InstanceType, string) {
+func pickBestInstanceType(nodeClaim *corev1.NodeClaim, instanceTypes corecloudprovider.InstanceTypes) (*corecloudprovider.InstanceType, string, string) {
 	if len(instanceTypes) == 0 {
-		return nil, ""
+		return nil, "", ""
 	}
 
 	sortedInstanceType := instanceTypes.OrderByPrice(scheduling.NewNodeSelectorRequirementsWithMinValues(nodeClaim.Spec.Requirements...))
@@ -258,14 +255,28 @@ func pickBestInstanceType(nodeClaim *corev1.NodeClaim, instanceTypes corecloudpr
 		return requestedZones.Has(o.Requirements.Get(v1.LabelTopologyZone).Any())
 	})
 	if len(priorityOfferings) == 0 {
-		return nil, ""
+		return nil, "", ""
 	}
 	zonesWithPriority := lo.Map(priorityOfferings, func(o *corecloudprovider.Offering, _ int) string {
 		return o.Requirements.Get(v1.LabelTopologyZone).Any()
 	})
 	// todo balance between different zone
 	mutable.Shuffle(zonesWithPriority)
-	return instanceType, zonesWithPriority[0]
+	selectedZone := zonesWithPriority[0]
+
+	// Find the cheapest available offering in the selected zone to determine capacity type
+	zoneOfferings := lo.Filter(priorityOfferings, func(o *corecloudprovider.Offering, _ int) bool {
+		return o.Requirements.Get(v1.LabelTopologyZone).Any() == selectedZone
+	})
+	// Sort by price to pick cheapest (which respects unavailable cache since we filtered by Available() above)
+	sort.Slice(zoneOfferings, func(i, j int) bool {
+		return zoneOfferings[i].Price < zoneOfferings[j].Price
+	})
+	capacityType := corev1.CapacityTypeOnDemand
+	if len(zoneOfferings) > 0 {
+		capacityType = zoneOfferings[0].Requirements.Get(corev1.CapacityTypeLabelKey).Any()
+	}
+	return instanceType, selectedZone, capacityType
 }
 
 func getIntValFromRequirements(key string, requirements scheduling.Requirements) (int, error) {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -181,7 +181,7 @@ func (p *Provider) Create(ctx context.Context, nodeClass *v1alpha1.OciNodeClass,
 			// for the second, you can request a service limit increase from the Console's Limits, Quotas and Usage page or from the Help menu.
 			if (typed.GetHTTPStatusCode() == 500 && strings.Contains(typed.GetMessage(), "Out of host capacity")) ||
 				(typed.GetHTTPStatusCode() == 400 && strings.Contains(typed.GetMessage(), "service limits were exceeded")) {
-				p.unavailableOfferings.MarkUnavailableForLaunchInstanceErr(ctx, err, capacityType, instanceType.Name, zone)
+				p.unavailableOfferings.MarkUnavailableForLaunchInstanceErr(ctx, err, capacityType, instanceType.Requirements.Get(v1alpha1.LabelInstanceShapeName).Any(), zone)
 				return nil, corecloudprovider.NewInsufficientCapacityError(fmt.Errorf("InsufficientCapacityError: %s", typed.GetMessage()))
 			}
 		}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -181,7 +181,7 @@ func (p *Provider) Create(ctx context.Context, nodeClass *v1alpha1.OciNodeClass,
 			// for the second, you can request a service limit increase from the Console's Limits, Quotas and Usage page or from the Help menu.
 			if (typed.GetHTTPStatusCode() == 500 && strings.Contains(typed.GetMessage(), "Out of host capacity")) ||
 				(typed.GetHTTPStatusCode() == 400 && strings.Contains(typed.GetMessage(), "service limits were exceeded")) {
-				p.unavailableOfferings.MarkUnavailableForLaunchInstanceErr(ctx, err, corev1.CapacityTypeOnDemand, instanceType.Name, zone)
+				p.unavailableOfferings.MarkUnavailableForLaunchInstanceErr(ctx, err, capacityType, instanceType.Name, zone)
 				return nil, corecloudprovider.NewInsufficientCapacityError(fmt.Errorf("InsufficientCapacityError: %s", typed.GetMessage()))
 			}
 		}

--- a/pkg/providers/instance/suite_test.go
+++ b/pkg/providers/instance/suite_test.go
@@ -297,4 +297,110 @@ var _ = Describe("InstanceProvider", func() {
 		Expect(err).ToNot(BeNil())
 		Expect(err.Error() == "not enough IPs are available on all subnets").To(BeTrue())
 	})
+	It("should fall back to on-demand when preemptible is marked unavailable", func() {
+		// Override PreemptibleShapes so shape-1 is treated as preemptible-capable
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+			ClusterName:       utils.String("test-cluster"),
+			AvailableDomains:  []string{"JPqd:US-ASHBURN-AD-1", "JPqd:US-ASHBURN-AD-2", "JPqd:US-ASHBURN-AD-3"},
+			PreemptibleShapes: lo.ToPtr("shape"),
+		}))
+		// Flush instance type cache so offerings are rebuilt with the new options
+		ociEnv.InstanceTypeCache.Flush()
+
+		// Allow both capacity types on the NodeClaim
+		nodeClaim.Spec.Requirements = append(nodeClaim.Spec.Requirements,
+			v1.NodeSelectorRequirementWithMinValues{
+				NodeSelectorRequirement: v1core.NodeSelectorRequirement{
+					Key:      v1.CapacityTypeLabelKey,
+					Operator: v1core.NodeSelectorOpIn,
+					Values:   []string{v1.CapacityTypeOnDemand, v1alpha1.CapacityTypePreemptible},
+				},
+			},
+			v1.NodeSelectorRequirementWithMinValues{
+				NodeSelectorRequirement: v1core.NodeSelectorRequirement{
+					Key:      v1core.LabelTopologyZone,
+					Operator: v1core.NodeSelectorOpIn,
+					Values:   []string{"US-ASHBURN-AD-1", "US-ASHBURN-AD-2", "US-ASHBURN-AD-3"},
+				},
+			},
+		)
+		ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+
+		// Mark preemptible as unavailable for shape-1 in ALL zones
+		for _, zone := range []string{"US-ASHBURN-AD-1", "US-ASHBURN-AD-2", "US-ASHBURN-AD-3"} {
+			ociEnv.UnavailableOfferingsCache.MarkUnavailable(ctx, "Out of host capacity", "shape-1", zone, v1alpha1.CapacityTypePreemptible)
+		}
+
+		// Get instance types — CreateOfferings will check the unavailable cache,
+		// so preemptible offerings for shape-1 will have Available=false
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Filter to shape-1 only
+		instanceTypes = lo.Filter(instanceTypes, func(i *corecloudprovider.InstanceType, _ int) bool {
+			return i.Name == "shape-1"
+		})
+		Expect(instanceTypes).To(HaveLen(1))
+
+		// Verify shape-1 still has available offerings (on-demand should be available)
+		available := instanceTypes[0].Offerings.Available()
+		Expect(len(available)).To(BeNumerically(">", 0))
+
+		// Create should succeed using on-demand (not preemptible)
+		instance, err := ociEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, instanceTypes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instance).ToNot(BeNil())
+
+		// Verify the launch request did NOT set PreemptibleInstanceConfig
+		Expect(ociEnv.CmpCli.LaunchInstanceBehavior.CalledWithInput.Len()).To(Equal(1))
+		launchInput := ociEnv.CmpCli.LaunchInstanceBehavior.CalledWithInput.Pop()
+		Expect(launchInput.PreemptibleInstanceConfig).To(BeNil(), "expected on-demand launch but got preemptible")
+	})
+	It("should use preemptible when it is available and cheapest", func() {
+		// Override PreemptibleShapes so shape-1 is treated as preemptible-capable
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{
+			ClusterName:       utils.String("test-cluster"),
+			AvailableDomains:  []string{"JPqd:US-ASHBURN-AD-1", "JPqd:US-ASHBURN-AD-2", "JPqd:US-ASHBURN-AD-3"},
+			PreemptibleShapes: lo.ToPtr("shape"),
+		}))
+		// Flush instance type cache so offerings are rebuilt with the new options
+		ociEnv.InstanceTypeCache.Flush()
+
+		// Allow both capacity types on the NodeClaim
+		nodeClaim.Spec.Requirements = append(nodeClaim.Spec.Requirements,
+			v1.NodeSelectorRequirementWithMinValues{
+				NodeSelectorRequirement: v1core.NodeSelectorRequirement{
+					Key:      v1.CapacityTypeLabelKey,
+					Operator: v1core.NodeSelectorOpIn,
+					Values:   []string{v1.CapacityTypeOnDemand, v1alpha1.CapacityTypePreemptible},
+				},
+			},
+			v1.NodeSelectorRequirementWithMinValues{
+				NodeSelectorRequirement: v1core.NodeSelectorRequirement{
+					Key:      v1core.LabelTopologyZone,
+					Operator: v1core.NodeSelectorOpIn,
+					Values:   []string{"US-ASHBURN-AD-1", "US-ASHBURN-AD-2", "US-ASHBURN-AD-3"},
+				},
+			},
+		)
+		ExpectApplied(ctx, env.Client, nodeClaim, nodePool, nodeClass)
+
+		// Do NOT mark anything unavailable — preemptible should win (50% cheaper)
+		instanceTypes, err := cloudProvider.GetInstanceTypes(ctx, nodePool)
+		Expect(err).ToNot(HaveOccurred())
+
+		instanceTypes = lo.Filter(instanceTypes, func(i *corecloudprovider.InstanceType, _ int) bool {
+			return i.Name == "shape-1"
+		})
+		Expect(instanceTypes).To(HaveLen(1))
+
+		instance, err := ociEnv.InstanceProvider.Create(ctx, nodeClass, nodeClaim, instanceTypes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(instance).ToNot(BeNil())
+
+		// Verify the launch request DID set PreemptibleInstanceConfig
+		Expect(ociEnv.CmpCli.LaunchInstanceBehavior.CalledWithInput.Len()).To(Equal(1))
+		launchInput := ociEnv.CmpCli.LaunchInstanceBehavior.CalledWithInput.Pop()
+		Expect(launchInput.PreemptibleInstanceConfig).ToNot(BeNil(), "expected preemptible launch but got on-demand")
+	})
 })


### PR DESCRIPTION
# Summary

Fixes three compounding bugs that prevented Karpenter from falling back to on-demand capacity when preemptible instance launches fail with "Out of host capacity" (ICE) errors. Each bug independently defeated the unavailable offerings cache, meaning all three had to be fixed together for the fallback to work.

## Bug 1: Wrong capacity type written to cache
`MarkUnavailableForLaunchInstanceErr` was called with a hardcoded `CapacityTypeOnDemand` instead of the actual capacity type. Preemptible ICE errors marked on-demand as unavailable — the exact opposite of correct behavior.

**Fix:** Pass the actual `capacityType` variable from the launch path.

## Bug 2: Cache key mismatch between write and read
The ICE handler wrote the cache key using `instanceType.Name` — the composite key like `VM.Standard.E4.Flex-8-16384` (shape-cpu-mem). But `CreateOfferings` checked `IsUnavailable` using the raw OCI shape name `VM.Standard.E4.Flex`. The keys never matched, making the cache a no-op.

**Fix:** Use `instanceType.Requirements.Get(LabelInstanceShapeName).Any()` to get the raw shape name when writing the cache key.

## Bug 3: Capacity type for launch derived from NodeClaim requirements, not selected offering
When a NodePool allows both on-demand and preemptible, the NodeClaim's `spec.requirements` contains `capacity-type: In [on-demand, preemptible]`. The `Create` method checked `nodeReqs.Has("preemptible")` — always true — so it always launched preemptible, even when the unavailable cache had correctly filtered preemptible offerings out and `pickBestInstanceType` had sorted on-demand as the cheapest available option.

**Fix:** `pickBestInstanceType` now returns the capacity type of the cheapest available offering for the selected zone, and `Create` uses that instead of reading from the NodeClaim requirements.

## Verification
- All three fixes deployed to production cluster in US-ASHBURN-AD-1
- `mix-large` NodePool (single shape `VM.Standard3.Flex`): 8/8 nodeclaims launched as `capacity-type: on-demand` after preemptible ICE — confirmed fallback working
- Unit tests added covering both the fallback path (preemptible unavailable → on-demand launch) and the happy path (preemptible available → preemptible launch)